### PR TITLE
fix: _animationController methods should not be called after widget disposed.

### DIFF
--- a/lib/scanning_effect.dart
+++ b/lib/scanning_effect.dart
@@ -68,9 +68,11 @@ class _ScanningEffectState extends State<ScanningEffect>
           Future.delayed(
             widget.delay,
             () {
-              _animationController
-                ..reset()
-                ..forward(from: 0);
+              if(mounted) {
+                _animationController
+                  ..reset()
+                  ..forward(from: 0);
+              }
             },
           );
         }


### PR DESCRIPTION
as title described.